### PR TITLE
[PW-1956] adds elodebit to combo card mapping

### DIFF
--- a/packages/client-extension/widget/AdyenPaymentWidget/js/components/component.js
+++ b/packages/client-extension/widget/AdyenPaymentWidget/js/components/component.js
@@ -20,7 +20,8 @@ class Component {
     }
 
     getComboCardOptions = () => {
-        const brands = { visa: constants.bins.electron, mc: constants.bins.maestro }
+        const { electron, maestro, elodebit } = constants.bins
+        const brands = { visa: electron, mc: maestro, elo: elodebit }
         const selectedComboCard = store.get(constants.selectedComboCard)()
         const isDebitCard = selectedComboCard === constants.comboCards.debit
         const brand = store.get(constants.selectedBrand)

--- a/packages/client-extension/widget/AdyenPaymentWidget/js/constants/index.js
+++ b/packages/client-extension/widget/AdyenPaymentWidget/js/constants/index.js
@@ -21,7 +21,7 @@ export const countries = {
 }
 export const brazilEnabled = 'brazilEnabled'
 export const comboCards = { debit: 'debitCard', credit: 'creditCard' }
-export const bins = { electron: 'electron', maestro: 'maestro' }
+export const bins = { electron: 'electron', maestro: 'maestro', elodebit: 'elodebit' }
 export const storage = { paymentData: 'AdyenPaymentData', order: 'AdyenOrder' }
 export const noInstallmentsMsg = 'noInstallmentsMsg'
 


### PR DESCRIPTION
When debit combo card is selected, `elo` bin should be mapped as `elodebit`